### PR TITLE
Feature avoid open project in new window when vscode is empty

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -15,6 +15,17 @@ const {fetchPathDescription, enhanceWithDescriptions, fetchProjectsFolders, fetc
 
 /* HELPERS */
 
+function vscodeIsEmpty () {
+  const workspaceFolders = vscode.workspace.workspaceFolders;
+  const visibleTextEditors = vscode.window.visibleTextEditors;
+  const activeTextEditor = vscode.window.activeTextEditor;
+
+  return (workspaceFolders == null || workspaceFolders.length === 0)
+        && (visibleTextEditors == null || visibleTextEditors.length === 0)
+        && activeTextEditor == null;
+
+}
+
 function helperOpenProject ( project, inNewWindow: boolean = false ) {
 
   const {name, path} = project,
@@ -384,6 +395,12 @@ async function viewSwitchGroup ( Item: ViewGroupItem ) {
 
 }
 
+function viewItemSmartOpenProject ( project, inNewWindow: boolean = false ) {
+
+  return helperOpenProject ( project, !vscodeIsEmpty() && inNewWindow );
+
+}
+
 /* EXPORT */
 
-export {initConfig, editConfig, open, openInNewWindow, openByName, addToWorkspace, helperOpenProject, helperAddProjectToWorkspace, helperOpenGroup, refresh, remove, save, openGroup, switchGroup, viewOpenProject, viewOpenProjectInNewWindow, viewAddProjectToWorkspace, viewOpenGroup, viewSwitchGroup};
+export {initConfig, editConfig, open, openInNewWindow, openByName, addToWorkspace, helperOpenProject, helperAddProjectToWorkspace, helperOpenGroup, refresh, remove, save, openGroup, switchGroup, viewOpenProject, viewOpenProjectInNewWindow, viewAddProjectToWorkspace, viewOpenGroup, viewSwitchGroup, viewItemSmartOpenProject};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,7 +44,7 @@ const Utils = {
 
     /* HARD CODED */
 
-    ['projects.helperOpenProject', 'helperAddProjectToWorkspace', 'projects.helperOpenGroup', 'projects.openByName'].forEach ( command => {
+    ['projects.helperOpenProject', 'helperAddProjectToWorkspace', 'projects.helperOpenGroup', 'projects.openByName', 'projects.viewItemSmartOpenProject'].forEach ( command => {
 
       const commandName = _.last ( command.split ( '.' ) ) as string,
             handler = Commands[commandName],
@@ -695,7 +695,7 @@ const Utils = {
         const command = {
           title: 'open',
           tooltip: `Open ${obj.name}`,
-          command: 'projects.helperOpenProject',
+          command: 'projects.viewItemSmartOpenProject',
           arguments: [obj, config.viewOpenInNewWindow]
         };
 


### PR DESCRIPTION
a new command was created that takes into account the status of vscode, not just the configuration.
this new command is used when a project is clicked in the list view
resolve issue #37 