### PR TITLE
Create a URI from a file system path

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -503,9 +503,9 @@ const Utils = {
 
     getProjectByPath ( obj, path ) {
 
-      path = vscode.Uri.parse ( Utils.path.untildify ( path ) ).fsPath;
+      path = vscode.Uri.file ( Utils.path.untildify ( path ) ).fsPath;
 
-      return Utils.config.getProjects ( obj ).find ( project => vscode.Uri.parse ( Utils.path.untildify ( project.path ) ).fsPath === path );
+      return Utils.config.getProjects ( obj ).find ( project => vscode.Uri.file ( Utils.path.untildify ( project.path ) ).fsPath === path );
 
     }
 


### PR DESCRIPTION
Closes #39 

* Instead of allowing parsing arbitrary URI schemas


The issue is due to `Uri.parse` allowing any kind of URI, from 'untitled' to 'http' to 'file' to 'vscode-resource' (this one should be used by Webview to restrict access to only certain files/paths).

The above fix explicitly parses path using a file schema.

The best documentation I found on this was reading comments in the `vscode.d.ts` file.