### PR TITLE
Move _IconsRight to TreeItem.description

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/fabiospampinato/vscode-projects-plus"
   },
   "engines": {
-    "vscode": "^1.21.0"
+    "vscode": "^1.30.0"
   },
   "keywords": [
     "vscode",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -696,8 +696,8 @@ const Utils = {
 
       const icon = obj.icon ? ( Utils.icons.ASCII[obj.icon] ? `${Utils.icons.ASCII[obj.icon]} ` : '' ) : '',
             _iconsLeft = obj._iconsLeft ? `${obj._iconsLeft.join ( ' ' )} ` : '', //TODO: Make this public
-            _iconsRight = obj._iconsRight ? ` ${obj._iconsRight.join ( ' ' )}` : '', //TODO: Make this public
-            name = `${_iconsLeft}${icon}${obj.name}${_iconsRight}`;
+            _iconsRight = obj._iconsRight ? obj._iconsRight.join ( ' ' ) : '', //TODO: Make this public
+            name = `${_iconsLeft}${icon}${obj.name}`;
 
       if ( obj.path ) { // Project
 
@@ -708,7 +708,7 @@ const Utils = {
           arguments: [obj, config.viewOpenInNewWindow, true]
         };
 
-        return new ViewProjectItem ( obj, name, command, vscode.TreeItemCollapsibleState.None );
+        return new ViewProjectItem ( obj, name, command, vscode.TreeItemCollapsibleState.None, _iconsRight );
 
       } else { // Group
 

--- a/src/views/items/item.ts
+++ b/src/views/items/item.ts
@@ -11,13 +11,7 @@ class Item extends vscode.TreeItem {
 
   contextValue = 'item';
 
-  constructor (
-    obj,
-    label: string,
-    command?: vscode.Command,
-    collapsibleState: vscode.TreeItemCollapsibleState = vscode.TreeItemCollapsibleState.Expanded,
-    description?: string,
-  ) {
+  constructor ( obj, label: string, command?: vscode.Command, collapsibleState: vscode.TreeItemCollapsibleState = vscode.TreeItemCollapsibleState.Expanded, description?: string ) {
 
     super ( label, collapsibleState );
 

--- a/src/views/items/item.ts
+++ b/src/views/items/item.ts
@@ -11,13 +11,20 @@ class Item extends vscode.TreeItem {
 
   contextValue = 'item';
 
-  constructor ( obj, label: string, command?: vscode.Command, collapsibleState: vscode.TreeItemCollapsibleState = vscode.TreeItemCollapsibleState.Expanded ) {
+  constructor (
+    obj,
+    label: string,
+    command?: vscode.Command,
+    collapsibleState: vscode.TreeItemCollapsibleState = vscode.TreeItemCollapsibleState.Expanded,
+    description?: string,
+  ) {
 
     super ( label, collapsibleState );
 
     this.obj = obj;
     this.command = command;
     this.tooltip = obj.description;
+    this.description = description;
 
   }
 


### PR DESCRIPTION
As discused on #26, this PR moves the _Check Dirty_, _Check Paths_, and _Show Ahead Behind_ icons to the `TreeItem`'s description to improve the project's tree readability.