### PR TITLE
Add `inferGroups` option, fixes #30

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,11 @@
           "description": "Root paths from where to start searching for projects",
           "default": []
         },
+        "projects.inferGroups": {
+          "type": "boolean",
+          "description": "Infer groups from the folder structure in the refresh paths",
+          "default": false
+        },
         "projects.sortGroups": {
           "type": "boolean",
           "description": "Sort groups alphabetically",

--- a/src/fetchers/projects/folders.ts
+++ b/src/fetchers/projects/folders.ts
@@ -58,12 +58,36 @@ async function fetchProjectsFolders ( roots, depth, ignoreFolders, matchFolders 
 
           if ( !isRepository ) return true;
 
-          if ( !found.projects ) found.projects = [];
-
           const projectName = path.basename ( dir ),
                 projectPath = config.useTilde ? Utils.path.tildify ( dir ) : dir;
 
-          found.projects.push ({
+          let obj = found;
+
+          if ( config.inferGroups ) {
+            const groups = path.relative( root, path.dirname( dir ) ).split( path.sep );
+
+            obj = groups.reduce( ( acc, group ) => {
+              if ( !acc.groups ) acc.groups = [];
+
+              const foundGroup = acc.groups.find( x => x.name == group );
+
+              if ( foundGroup ) {
+                return foundGroup;
+              }
+
+              const newObj = {
+                name: group,
+              };
+
+              acc.groups.push( newObj );
+
+              return newObj;
+            }, found );
+          }
+
+          if ( !obj.projects ) obj.projects = [];
+
+          obj.projects.push ({
             name: projectName,
             path: projectPath
           });


### PR DESCRIPTION
This new option allows people to let this extension infer the groups from the directory structure in the refreshRoot paths.
